### PR TITLE
Fixed to allow new values to be entered in “Keywords” and “Specialties”

### DIFF
--- a/src/components/DataJoinEditor/DataJoinEditorInput.js
+++ b/src/components/DataJoinEditor/DataJoinEditorInput.js
@@ -1,13 +1,15 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Chip from '@material-ui/core/Chip';
-import Autocomplete from '@material-ui/lab/Autocomplete';
+import Autocomplete, { createFilterOptions } from '@material-ui/lab/Autocomplete';
 import TextField from '@material-ui/core/TextField';
 
 import {
   asyncListAll,
 } from 'utils/graph';
 import { getPropsByMode } from './helpers';
+
+const filter = createFilterOptions();
 
 export default function DataJoinEditorInput({
   title = '',
@@ -23,7 +25,14 @@ export default function DataJoinEditorInput({
   const [values, setValues] = useState([]);
   const [defaultValues, setDefaultValues] = useState(inDefaultValues);
 
-  const handleChange = (event, values) => {
+  const handleChange = (event, newValues) => {
+    const values = newValues.map((item) => {
+      if (typeof item === 'string') {
+        return item;
+      } else {
+        return item.inputValue;
+      }
+    });
     setValues([...values]);
     onChange(values);
   };
@@ -65,10 +74,28 @@ export default function DataJoinEditorInput({
         id="tags-filled"
         options={filteredOptions}
         defaultValue={defaultValues}
+        selectOnFocus
+        clearOnBlur
         freeSolo
+        filterOptions={(options, params) => {
+          const filtered = filter(options, params);
+          if (params.inputValue !== '') {
+            filtered.push({
+              inputValue: params.inputValue,
+              title: `Add "${params.inputValue}"`,
+            });
+          }
+          return filtered;
+        }}
+        getOptionLabel={(option) => {
+          if (typeof option === 'string') {
+            return option;
+          }
+          return option.title;
+        }}
         renderTags={(value, getTagProps) =>
           value.map((option, index) => (
-            <Chip key={index} variant="outlined" label={option} {...getTagProps({ index })} />
+            <Chip key={index} variant="outlined" label={typeof option === 'string' ? option : option.inputValue} {...getTagProps({ index })} />
             // <React.Fragment key={index}>
             //   {chip({
             //     data: { label: option },


### PR DESCRIPTION
I can't seem to enter new words in the "Keywords" and "Specialties" fields.

![スクリーンショット 2021-06-09 15 22 11](https://user-images.githubusercontent.com/14883063/121304111-e4dc6c80-c936-11eb-866f-2efd2f13a7ee.png)

So I made it possible to enter a new words in that field.

![スクリーンショット 2021-06-09 15 19 05](https://user-images.githubusercontent.com/14883063/121304285-1e14dc80-c937-11eb-8dfc-6f4ac8d2e497.png)
![スクリーンショット 2021-06-09 15 19 30](https://user-images.githubusercontent.com/14883063/121304307-24a35400-c937-11eb-9c0a-cbd89ee9c90c.png)
![スクリーンショット 2021-06-09 15 19 41](https://user-images.githubusercontent.com/14883063/121304334-2a993500-c937-11eb-8741-739b6db62fae.png)
