### PR TITLE
add auxiliary text to the "Keywords" and "Specialties" input fields

### DIFF
--- a/public/assets/i18n/translations/en-US.yaml
+++ b/public/assets/i18n/translations/en-US.yaml
@@ -41,6 +41,7 @@ user_participateProjects: Contributed Projects
 user_recentContributions: Recent Contributions
 user_hours: Hour(s)
 user_needs: Specialties
+user_inputTagsHelperText: Please press Enter to add a new one.
 
 project_links: Links
 project_tags: Tags

--- a/public/assets/i18n/translations/zh-TW.yaml
+++ b/public/assets/i18n/translations/zh-TW.yaml
@@ -41,6 +41,7 @@ user_participateProjects: 參與的專案
 user_recentContributions: 近期貢獻紀錄
 user_hours: 小時
 user_needs: 專長
+user_inputTagsHelperText: Please press Enter to add a new one.
 
 project_links: 文件連結
 project_tags: 標籤

--- a/src/components/DataJoinEditor/DataJoinEditorInput.js
+++ b/src/components/DataJoinEditor/DataJoinEditorInput.js
@@ -3,11 +3,13 @@ import PropTypes from 'prop-types';
 import Chip from '@material-ui/core/Chip';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import TextField from '@material-ui/core/TextField';
+import FormHelperText from '@material-ui/core/FormHelperText';
 
 import {
   asyncListAll,
 } from 'utils/graph';
 import { getPropsByMode } from './helpers';
+import { useTranslation } from 'react-i18next';
 
 export default function DataJoinEditorInput({
   title = '',
@@ -24,6 +26,7 @@ export default function DataJoinEditorInput({
   const [values, setValues] = useState([]);
   const [defaultValues, setDefaultValues] = useState(inDefaultValues);
   const [freeSolo, setFreeSolo] = useState(inFreeSolo);
+  const { t } = useTranslation();
 
   const handleChange = (event, values) => {
     setValues([...values]);
@@ -89,7 +92,9 @@ export default function DataJoinEditorInput({
         )}
         onChange={handleChange}
         disabled={disabled}
+        aria-describedby="tags-filled-helper-text"
       />
+      <FormHelperText id="tags-filled-helper-text">{t('user_inputTagsHelperText')}</FormHelperText>
     </React.Fragment>
   );
 }


### PR DESCRIPTION
I have added auxiliary text to the "Keywords" and "Specialties" input fields. Because I don't know how to add a new word.

![スクリーンショット 2021-06-14 15 27 25](https://user-images.githubusercontent.com/14883063/121849675-99570380-cd26-11eb-990c-796df946a7d7.png)
